### PR TITLE
IRON-29 fix iOS 9 issue with redirect following fix for iOS 12

### DIFF
--- a/src/Ironclad/Sdk/AuthCookieMiddleware.cs
+++ b/src/Ironclad/Sdk/AuthCookieMiddleware.cs
@@ -3,8 +3,11 @@
 
 namespace Ironclad.Sdk
 {
+    using System;
+    using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Http;
@@ -12,6 +15,7 @@ namespace Ironclad.Sdk
 
     public class AuthCookieMiddleware
     {
+        private static Regex regex = new Regex(@"OS ((\d+_?){2,3})\s", RegexOptions.Compiled);
         private readonly RequestDelegate next;
 
         public AuthCookieMiddleware(RequestDelegate next)
@@ -21,6 +25,12 @@ namespace Ironclad.Sdk
 
         public async Task Invoke(HttpContext context)
         {
+            if (!this.RequiresSameSiteCookieFix(context))
+            {
+                await this.next.Invoke(context);
+                return;
+            }
+
             var schemeProvider = context.RequestServices.GetRequiredService<IAuthenticationSchemeProvider>();
             var handlerProvider = context.RequestServices.GetRequiredService<IAuthenticationHandlerProvider>();
 
@@ -55,6 +65,32 @@ namespace Ironclad.Sdk
             }
 
             await this.next.Invoke(context);
+        }
+
+        // LINK: https://github.com/IdentityServer/IdentityServer4/issues/2595#issuecomment-425068595
+        private bool RequiresSameSiteCookieFix(HttpContext context)
+        {
+            var userAgent = context.Request.Headers["User-Agent"].ToString();
+            var groups = regex.Matches(userAgent);
+
+            if (groups.Count == 0)
+            {
+                return false;
+            }
+
+            var captures = groups[0].Captures;
+
+            if (captures.Count == 0)
+            {
+                return false;
+            }
+
+            // Captured version might be in a form of a semver, ie. 'OS 10_3_0'
+            var version = captures[0].Value
+                .Replace("OS ", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                .Split('_', StringSplitOptions.None)[0];
+
+            return int.TryParse(version, NumberStyles.Any, CultureInfo.InvariantCulture, out var v) && v >= 12;
         }
     }
 }


### PR DESCRIPTION
It is a very simple fix that works. If you do not like the way I am parsing User-Agent header, I can switch to some external library that does the same thing, ie. https://github.com/ua-parser/uap-csharp