### PR TITLE
IRON-30 Enable one instance of Ironclad to be managed by another

### DIFF
--- a/src/Ironclad.Console/Commands/auth-login/LoginCommand.cs
+++ b/src/Ironclad.Console/Commands/auth-login/LoginCommand.cs
@@ -16,6 +16,7 @@ namespace Ironclad.Console.Commands
     internal class LoginCommand : ICommand
     {
         private Api apiResponse;
+        private string apiUri;
 
         private LoginCommand()
         {
@@ -33,6 +34,7 @@ namespace Ironclad.Console.Commands
 
             // options
             var optionReset = app.Option("-r|--reset", "Resets the authorization context", CommandOptionType.NoValue);
+            var optionApiUri = app.Option("-a|--api", "Specifies a custom API URI to use", CommandOptionType.SingleValue, config => config.ShowInHelpText = false);
             app.HelpOption();
 
             // action (for this command)
@@ -66,7 +68,7 @@ namespace Ironclad.Console.Commands
                         }
                     }
 
-                    var apiUri = discoveryResponse.TryGetString("api_uri") ?? authority;
+                    var apiUri = optionApiUri.Value() ?? discoveryResponse.TryGetString("api_uri") ?? authority + "/api";
 
                     var apiResponse = default(Api);
                     using (var client = new HttpClient())
@@ -96,7 +98,7 @@ namespace Ironclad.Console.Commands
                         return;
                     }
 
-                    options.Command = new LoginCommand { Authority = authority, apiResponse = apiResponse };
+                    options.Command = new LoginCommand { Authority = authority, apiResponse = apiResponse, apiUri = apiUri };
                 });
         }
 
@@ -153,6 +155,7 @@ namespace Ironclad.Console.Commands
                 new CommandData
                 {
                     Authority = this.Authority,
+                    ApiUri = this.apiUri,
                     AccessToken = result.AccessToken,
                     AccessTokenExpiration = result.AccessTokenExpiration,
                     RefreshToken = result.RefreshToken,

--- a/src/Ironclad.Console/Persistence/CommandData.cs
+++ b/src/Ironclad.Console/Persistence/CommandData.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CA1056
+
 namespace Ironclad.Console.Persistence
 {
     using System;
@@ -8,6 +10,8 @@ namespace Ironclad.Console.Persistence
     public class CommandData
     {
         public string Authority { get; set; }
+
+        public string ApiUri { get; set; }
 
         public string AccessToken { get; set; }
 

--- a/src/Ironclad.Console/Persistence/CommandDataRepository.cs
+++ b/src/Ironclad.Console/Persistence/CommandDataRepository.cs
@@ -35,6 +35,7 @@ namespace Ironclad.Console.Persistence
             return new CommandData
             {
                 Authority = data.Authority,
+                ApiUri = data.ApiUri,
                 AccessToken = this.protector.Unprotect(data.AccessToken),
                 AccessTokenExpiration = data.AccessTokenExpiration,
                 RefreshToken = this.protector.Unprotect(data.RefreshToken),
@@ -45,7 +46,7 @@ namespace Ironclad.Console.Persistence
         {
             if (commandData == null)
             {
-                var filename = Path.Combine(this.innerRepository.Directory.FullName, "command-data.xml");
+                var filename = Path.Combine(this.innerRepository.Directory.FullName, "config.xml");
                 File.Delete(filename); // won't throw if the file doesn't exist
                 return;
             }
@@ -54,6 +55,7 @@ namespace Ironclad.Console.Persistence
             var data = new CommandData
             {
                 Authority = commandData.Authority,
+                ApiUri = commandData.ApiUri,
                 AccessToken = this.protector.Protect(commandData.AccessToken),
                 AccessTokenExpiration = commandData.AccessTokenExpiration,
                 RefreshToken = this.protector.Protect(commandData.RefreshToken),
@@ -65,7 +67,7 @@ namespace Ironclad.Console.Persistence
                 Serializer.Serialize(streamWriter, data);
 
                 var xml = XElement.Parse(Encoding.ASCII.GetString(memoryStream.ToArray()));
-                this.innerRepository.StoreElement(xml, "command-data");
+                this.innerRepository.StoreElement(xml, "config");
             }
         }
     }

--- a/src/Ironclad.Console/Persistence/CustomFileSystemXmlRepository.cs
+++ b/src/Ironclad.Console/Persistence/CustomFileSystemXmlRepository.cs
@@ -14,7 +14,7 @@ namespace Ironclad.Console.Persistence
 
     public class CustomFileSystemXmlRepository : FileSystemXmlRepository
     {
-        private const string RepositoryFolderName = "auth.exe";
+        private const string RepositoryFolderName = ".ironclad";
 
         public CustomFileSystemXmlRepository()
             : base(GetDefaultDataStorageDirectory(), NullLoggerFactory.Instance)
@@ -69,7 +69,7 @@ namespace Ironclad.Console.Persistence
             else if (homePath != null)
             {
                 // If LOCALAPPDATA and USERPROFILE are not present but HOME is, it's a good guess that this is a *NIX machine.  Use *NIX conventions for a folder name.
-                directoryInfo = new DirectoryInfo(Path.Combine(homePath, ".lykke", RepositoryFolderName));
+                directoryInfo = new DirectoryInfo(Path.Combine(homePath, RepositoryFolderName));
             }
             else if (!string.IsNullOrEmpty(localAppDataFromSystemPath))
             {
@@ -95,7 +95,7 @@ namespace Ironclad.Console.Persistence
             }
         }
 
-        private static DirectoryInfo GetKeyStorageDirectoryFromBaseAppDataPath(string basePath) => new DirectoryInfo(Path.Combine(basePath, "Lykke", RepositoryFolderName));
+        private static DirectoryInfo GetKeyStorageDirectoryFromBaseAppDataPath(string basePath) => new DirectoryInfo(Path.Combine(basePath, RepositoryFolderName));
 
         private void StoreElementCore(XElement element, string filename)
         {

--- a/src/Ironclad.Console/Program.cs
+++ b/src/Ironclad.Console/Program.cs
@@ -107,7 +107,7 @@ namespace Ironclad.Console
                 }
             }
 
-            var apiUri = discoveryResponse.TryGetString("api_uri") ?? authority + "/api";
+            var apiUri = data.ApiUri ?? discoveryResponse.TryGetString("api_uri") ?? authority + "/api";
 
             this.console.Write("Executing command against ");
             this.console.ForegroundColor = ConsoleColor.White;

--- a/src/Ironclad.Console/Program.cs
+++ b/src/Ironclad.Console/Program.cs
@@ -96,6 +96,12 @@ namespace Ironclad.Console
                 authority = loginCommand.Authority;
             }
 
+            if (string.IsNullOrEmpty(authority))
+            {
+                this.console.WriteLine("Not logged in.");
+                return 0;
+            }
+
             var discoveryResponse = default(DiscoveryResponse);
             using (var discoveryClient = new DiscoveryClient(authority) { Policy = new DiscoveryPolicy { ValidateIssuerName = false } })
             {


### PR DESCRIPTION
Fixes #71.

There is now an undocumented command to enable logging in to one instance of Ironclad and then using the API of another: `ironclad login http://localhost:5005 -a http://localhost:5006`
Where `http://localhost:5006` is a running instance of ironclad that has been set up as an API in the `http://localhost:5005` instance with the same API details as `auth_api`.

**http://localhost:5005 setup**:
```bash
>ironclad apis show ironclad_api
Executing command against https://localhost:5005/api...
{
  "name": "ironclad_api",
  "display_name": "Ironclad Managed Instance",
  "user_claims": [
    "name",
    "role"
  ],
  "api_scopes": [
    {
      "name": "auth_api",
      "user_claims": []
    },
    {
      "name": "auth_api:write",
      "user_claims": []
    }
  ],
  "enabled": true
}
```

**http://localhost:5006 config**:
```json
{
  "api": {
    "client_id": "ironclad_api",
    "secret":  "{secret}"
  }
}
```