### PR TITLE
IDENTITY-31 Optional PathBase, in order to serve static files behind …

### DIFF
--- a/src/Ironclad/Settings.cs
+++ b/src/Ironclad/Settings.cs
@@ -22,6 +22,8 @@ namespace Ironclad
 
         public ApiSettings Api { get; set; }
 
+        public WebsiteSettings Website { get; set; }
+
         public IdpSettings Idp { get; set; }
 
         public MailSettings Mail { get; set; }
@@ -219,6 +221,20 @@ Please see https://gist.github.com/cameronfletcher/58673a468c8ebbbf91b81e706063b
                 {
                     yield return $"'{{0}}:{nameof(this.Secret).ToLowerInvariant()}' is null or empty.";
                 }
+            }
+        }
+
+        public sealed class WebsiteSettings
+        {
+            public string PathBase { get; set; }
+
+            public bool IsValid() => !this.GetValidationErrors().Any();
+
+            public IEnumerable<string> GetValidationErrors()
+            {
+                // Note (Pawel) if you add validation here, please make sure to make this config section mandatory
+                // (for now it is optional)
+                return Array.Empty<string>();
             }
         }
 

--- a/src/Ironclad/Startup.cs
+++ b/src/Ironclad/Startup.cs
@@ -196,6 +196,12 @@ namespace Ironclad
             }
 
             app.UseMiddleware<AuthCookieMiddleware>();
+
+            if (!string.IsNullOrEmpty(this.settings.Website?.PathBase))
+            {
+                app.UsePathBase(this.settings.Website.PathBase);
+            }
+
             app.UseStaticFiles();
             app.UseIdentityServer();
             app.UseMvcWithDefaultRoute();


### PR DESCRIPTION
This adds optional pathBase to the app. If you add this config section to configuration:
```
  "website": {
    "pathBase": "/auth"
  },
```

ironclad will still be fully functional without prepending request path with `/auth` ie. http://localhost:5005/signin, however, requests starting with `pathBase` will be also supported, ie. http://localhost:5005/auth/signin The most important fact is that the latter will make UI to generate urls to static files with the path starting from `basePath`, ie. http://localhost:5005/auth/css/default.css

Inspired by @vidolch and https://www.billbogaiv.com/posts/net-core-hosted-on-subdirectories-in-nginx