### PR TITLE
IRON-52 Fixes #136 Changed API to displays git branch and commit SHA

### DIFF
--- a/build/build.cs
+++ b/build/build.cs
@@ -3,23 +3,24 @@
     using System;
     using System.IO;
     using Microsoft.Extensions.Configuration;
-
+    using McMaster.Extensions.CommandLineUtils;
+    using Newtonsoft.Json;
     using static Bullseye.Targets;
     using static SimpleExec.Command;
 
     internal static class Program
     {
-        private const string DetectEnvironment      = "env";
-        private const string RestoreNugetPackages   = "restore";
-        private const string BuildSolution          = "build";
-        private const string BuildDockerImage       = "docker";
-        private const string TestDockerImage        = "test";
-        private const string PublishDockerImage     = "publish-docker";
-        private const string CreateNugetPackages    = "pack";
-        private const string PublishNugetPackages   = "publish-nuget";
-        private const string PublishAll             = "publish";
-
-        private const string ArtifactsFolder        = "artifacts";
+        private const string DetectEnvironment = "env";
+        private const string RestoreNugetPackages = "restore";
+        private const string BuildSolution = "build";
+        private const string BuildDockerImage = "docker";
+        private const string TestDockerImage = "test";
+        private const string PublishDockerImage = "publish-docker";
+        private const string CreateNugetPackages = "pack";
+        private const string PublishNugetPackages = "publish-nuget";
+        private const string PublishAll = "publish";
+        private const string GitInfo = "git-info";
+        private const string ArtifactsFolder = "artifacts";
 
         public static void Main(string[] args)
         {
@@ -36,7 +37,13 @@
             var dockerPassword = default(string);
             var dockerTag = default(string);
 
-            Target(
+            var app = new CommandLineApplication(throwOnUnexpectedArg: false);
+            var buildOutputPath = app.Option<string>("--output", "Build output path", CommandOptionType.SingleValue);
+            var projectDirectoryPath = app.Option<string>("--project-dir", "Project directory path", CommandOptionType.SingleValue);
+
+            app.OnExecute(() =>
+            {
+                Target(
                 DetectEnvironment,
                 () =>
                 {
@@ -83,91 +90,132 @@
                     }
                 });
 
-            Target(
-                RestoreNugetPackages,
-                () => Run("dotnet", "restore src/Ironclad.sln"));
+                Target(
+                    RestoreNugetPackages,
+                    () => Run("dotnet", "restore src/Ironclad.sln"));
 
-            Target(
-                BuildSolution,
-                DependsOn(RestoreNugetPackages),
-                () => Run("dotnet", "build src/Ironclad.sln -c CI --no-restore"));
+                Target(
+                    BuildSolution,
+                    DependsOn(RestoreNugetPackages),
+                    () => Run("dotnet", "build src/Ironclad.sln -c CI --no-restore"));
 
-            Target(
-                BuildDockerImage,
-                () => Run("docker", "build --tag ironclad ."));
+                Target(
+                    BuildDockerImage,
+                    () => Run("docker", "build --tag ironclad ."));
 
-            Target(
-                TestDockerImage,
-                DependsOn(BuildSolution, BuildDockerImage),
-                // dotnet test --test-adapter-path:C:\Users\cameronfletcher\.nuget\packages\xunitxml.testlogger\2.0.0\build\_common --logger:"xunit;LogFilePath=test_result.xml"
-                () => Run("dotnet", $"test tests/Ironclad.Tests/Ironclad.Tests.csproj -r ../../../{ArtifactsFolder} -l trx;LogFileName=Ironclad.Tests.xml --no-build"));
+                Target(
+                    TestDockerImage,
+                    DependsOn(BuildSolution, BuildDockerImage),
+                    // dotnet test --test-adapter-path:C:\Users\cameronfletcher\.nuget\packages\xunitxml.testlogger\2.0.0\build\_common --logger:"xunit;LogFilePath=test_result.xml"
+                    () => Run("dotnet", $"test tests/Ironclad.Tests/Ironclad.Tests.csproj -r ../../../{ArtifactsFolder} -l trx;LogFileName=Ironclad.Tests.xml --no-build"));
 
-            Target(
-                CreateNugetPackages,
-                DependsOn(BuildSolution),
-                ForEach(
-                    "src/Ironclad.Client/Ironclad.Client.csproj", 
-                    "src/Ironclad.Console/Ironclad.Console.csproj", 
-                    "src/Ironclad.Tests.Sdk/Ironclad.Tests.Sdk.csproj"),
-                project => Run("dotnet", $"pack {project} -c Release -o ../../{(project.StartsWith("tests") ? "../" : "") + ArtifactsFolder} --no-build"));
+                Target(
+                    CreateNugetPackages,
+                    DependsOn(BuildSolution),
+                    ForEach(
+                        "src/Ironclad.Client/Ironclad.Client.csproj",
+                        "src/Ironclad.Console/Ironclad.Console.csproj",
+                        "src/Ironclad.Tests.Sdk/Ironclad.Tests.Sdk.csproj"),
+                    project => Run("dotnet", $"pack {project} -c Release -o ../../{(project.StartsWith("tests") ? "../" : "") + ArtifactsFolder} --no-build"));
 
-            Target(
-                PublishNugetPackages,
-                DependsOn(DetectEnvironment, CreateNugetPackages, TestDockerImage),
-                () =>
-                {
-                    var packagesToPublish = Directory.GetFiles(ArtifactsFolder, "*.nupkg", SearchOption.TopDirectoryOnly);
-                    Console.WriteLine($"Found packages to publish: {string.Join("; ", packagesToPublish)}");
-
-                    if (isPullRequest)
+                Target(
+                    PublishNugetPackages,
+                    DependsOn(DetectEnvironment, CreateNugetPackages, TestDockerImage),
+                    () =>
                     {
-                        Console.WriteLine("Build is pull request. Packages will not be published.");
-                        return;
-                    }
+                        var packagesToPublish = Directory.GetFiles(ArtifactsFolder, "*.nupkg", SearchOption.TopDirectoryOnly);
+                        Console.WriteLine($"Found packages to publish: {string.Join("; ", packagesToPublish)}");
 
-                    if (string.IsNullOrWhiteSpace(nugetServer) || string.IsNullOrWhiteSpace(nugetApiKey))
+                        if (isPullRequest)
+                        {
+                            Console.WriteLine("Build is pull request. Packages will not be published.");
+                            return;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(nugetServer) || string.IsNullOrWhiteSpace(nugetApiKey))
+                        {
+                            Console.WriteLine("NuGet settings not specified. Packages will not be published.");
+                            return;
+                        }
+
+                        foreach (var packageToPublish in packagesToPublish)
+                        {
+                            Run("dotnet", $"nuget push {packageToPublish} -s {nugetServer} -k {nugetApiKey}", noEcho: true);
+                        }
+                    });
+
+                Target(
+                    PublishDockerImage,
+                    DependsOn(DetectEnvironment, TestDockerImage),
+                    () =>
                     {
-                        Console.WriteLine("NuGet settings not specified. Packages will not be published.");
-                        return;
-                    }
+                        if (isPullRequest)
+                        {
+                            Console.WriteLine("Build is pull request. Docker images will not be published.");
+                            return;
+                        }
 
-                    foreach (var packageToPublish in packagesToPublish)
+                        if (string.IsNullOrWhiteSpace(dockerRegistry) || string.IsNullOrWhiteSpace(dockerUsername) || string.IsNullOrWhiteSpace(dockerPassword))
+                        {
+                            Console.WriteLine("Docker settings not specified. Docker images will not be published.");
+                            return;
+                        }
+
+                        Run("docker", $"login {dockerRegistry} -u {dockerUsername} -p {dockerPassword}");
+                        Run("docker", $"tag ironclad:latest {dockerRegistry}/ironclad:{dockerTag}");
+                        Run("docker", $"push {dockerRegistry}/ironclad:{dockerTag}");
+                    });
+
+                Target(
+                    GitInfo,
+                    () =>
                     {
-                        Run("dotnet", $"nuget push {packageToPublish} -s {nugetServer} -k {nugetApiKey}", noEcho: true);
-                    }
-                });
+                        if (!buildOutputPath.HasValue())
+                        {
+                            throw new ArgumentNullException("--output", "Build output parameter --output is mandatory.");
+                        }
 
-            Target(
-                PublishDockerImage,
-                DependsOn(DetectEnvironment, TestDockerImage),
-                () =>
-                {
-                    if (isPullRequest)
-                    {
-                        Console.WriteLine("Build is pull request. Docker images will not be published.");
-                        return;
-                    }
+                        if (!Path.IsPathFullyQualified(buildOutputPath.Value()) && !projectDirectoryPath.HasValue())
+                        {
+                            throw new ArgumentNullException("--project-dir",
+                                "Provided --output value is a relative path. Project directory parameter --project-dir in this case is mandatory.");
+                        }
 
-                    if (string.IsNullOrWhiteSpace(dockerRegistry) || string.IsNullOrWhiteSpace(dockerUsername) || string.IsNullOrWhiteSpace(dockerPassword))
-                    {
-                        Console.WriteLine("Docker settings not specified. Docker images will not be published.");
-                        return;
-                    }
+                        // Note (Pawel) by default if running 'dotnet build' or from VS,
+                        // --output is a relative path, ie. 'bin\Debug\netcoreapp2.1\'.
+                        // When you specify output path (dotnet run -o <path>), --output
+                        //is an absolute path.
+                        var outputDir = Path.IsPathFullyQualified(buildOutputPath.Value()) ? buildOutputPath.Value()
+                            : Path.Combine(projectDirectoryPath.Value(), buildOutputPath.Value());
 
-                    Run("docker", $"login {dockerRegistry} -u {dockerUsername} -p {dockerPassword}");
-                    Run("docker", $"tag ironclad:latest {dockerRegistry}/ironclad:{dockerTag}");
-                    Run("docker", $"push {dockerRegistry}/ironclad:{dockerTag}");
-                });
+                        var gitInfo = new
+                        {
+                            git = new
+                            {
+                                authorDate = Read("git", "log -n 1 --format=%ad").Replace("\n", string.Empty),
+                                branch = Read("git", "rev-parse --abbrev-ref HEAD").Replace("\n", string.Empty),
+                                commitSha = Read("git", "log -n 1 --format=%H").Replace("\n", string.Empty),
+                            }
+                        };
+                        var json = JsonConvert.SerializeObject(gitInfo);
+                        var configPath = Path.Combine(outputDir, "appsettings.Git.json");
 
-            Target(
+                        Console.WriteLine($"Writing config file {configPath}");
+                        File.WriteAllText(configPath, json);
+                    });
+
+                Target(
                     PublishAll,
                     DependsOn(PublishNugetPackages, PublishDockerImage));
 
-            Target(
-                    "default",
-                    DependsOn(PublishNugetPackages, PublishDockerImage));
+                Target(
+                        "default",
+                        DependsOn(PublishNugetPackages, PublishDockerImage));
 
-            RunTargets(args);
+                RunTargetsAndExit(app.RemainingArguments);
+            });
+
+            app.Execute(args);
         }
 
         private class Settings

--- a/build/build.csproj
+++ b/build/build.csproj
@@ -6,11 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bullseye" Version="2.2.0" />
+    <PackageReference Include="Bullseye" Version="2.3.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="SimpleExec" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="SimpleExec" Version="5.0.0-beta.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Ironclad/Ironclad.csproj
+++ b/src/Ironclad/Ironclad.csproj
@@ -20,13 +20,13 @@
   <ItemGroup>
     <TrimFilesRootFiles Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup.dll" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Remove="logs\**" />
     <EmbeddedResource Remove="logs\**" />
     <None Remove="logs\**" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.6.0" />
     <PackageReference Include="IdentityServer4.AspNetIdentity" Version="2.1.0" />
@@ -112,5 +112,14 @@
   <ItemGroup>
     <ProjectReference Include="..\Ironclad.ExternalIdentityProvider\Ironclad.ExternalIdentityProvider.csproj" />
   </ItemGroup>
+
+  <Target Name="GitInfo" AfterTargets="Build" Condition="'$(Configuration)'=='Release' Or '$(Configuration)'=='CI'">
+    <Exec Command="dotnet run -p ../../build/build.csproj -- --project-dir $(MSBuildProjectDirectory) --output $(OutputPath) git-info" />
+  </Target>
+
+  <Target Name="GitInfoPublish" AfterTargets="Publish" Condition="'$(Configuration)'=='Release' Or '$(Configuration)'=='CI'">
+    <Exec Command="dotnet run -p ../../build/build.csproj -- --output $(PublishDir) git-info" />
+  </Target>
+
 
 </Project>

--- a/src/Ironclad/Program.cs
+++ b/src/Ironclad/Program.cs
@@ -28,6 +28,7 @@ namespace Ironclad
             var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile($"appsettings.Git.json", optional: true)
                 .AddJsonFile($"appsettings.Custom.json", optional: true)
                 .AddJsonFile($"appsettings.{environmentName}.json", optional: true)
                 .AddUserSecrets<Startup>()

--- a/src/Ironclad/Startup.cs
+++ b/src/Ironclad/Startup.cs
@@ -15,6 +15,7 @@ namespace Ironclad
     using Ironclad.Models;
     using Ironclad.Sdk;
     using Ironclad.Services.Email;
+    using Ironclad.WebApi;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.DataProtection;
@@ -36,11 +37,13 @@ namespace Ironclad
         private readonly ILoggerFactory loggerFactory;
         private readonly Settings settings;
         private readonly WebsiteSettings websiteSettings;
+        private readonly ApiInfo apiInfo;
 
         public Startup(ILogger<Startup> logger, ILoggerFactory loggerFactory, IConfiguration configuration)
         {
             this.logger = logger;
             this.loggerFactory = loggerFactory;
+            this.apiInfo = new ApiInfo(configuration);
             this.settings = configuration.Get<Settings>(options => options.BindNonPublicProperties = true);
             this.websiteSettings = configuration.GetSection("website").Get<WebsiteSettings>(options => options.BindNonPublicProperties = true) ?? new WebsiteSettings();
             this.settings.Validate();
@@ -52,6 +55,7 @@ namespace Ironclad
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton(this.websiteSettings);
+            services.AddSingleton(this.apiInfo);
 
             services.AddDbContext<ApplicationDbContext>(options => options.UseNpgsql(this.settings.Server.Database));
 

--- a/src/Ironclad/WebApi/ApiInfo.cs
+++ b/src/Ironclad/WebApi/ApiInfo.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Lykke Corp.
+// See the LICENSE file in the project root for more information.
+#pragma warning disable CA1034 // Nested types should not be visible
+namespace Ironclad.WebApi
+{
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Reflection;
+    using Microsoft.Extensions.Configuration;
+
+    public class ApiInfo
+    {
+        public ApiInfo(IConfiguration configuration)
+        {
+            this.Title = typeof(Program).Assembly.Attribute<AssemblyTitleAttribute>(attribute => attribute.Title);
+            this.Version = typeof(Program).Assembly.Attribute<AssemblyInformationalVersionAttribute>(attribute => attribute.InformationalVersion);
+            this.OS = System.Runtime.InteropServices.RuntimeInformation.OSDescription.TrimEnd();
+            this.ProcessId = Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
+
+            if (Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") != null)
+            {
+                this.Azure = new ApiInfo.AzureInfo
+                {
+                    InstanceId = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"),
+                    SiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"),
+                };
+            }
+
+            if (configuration.GetValue<string>("git:branch") != null)
+            {
+                this.Git = new GitInfo
+                {
+                    AuthorDate = configuration.GetValue<string>("git:authorDate"),
+                    Branch = configuration.GetValue<string>("git:branch"),
+                    CommitSha = configuration.GetValue<string>("git:commitSha"),
+                };
+            }
+        }
+
+        public string Title { get; }
+
+        public string Version { get; }
+
+        public string OS { get; }
+
+        public string ProcessId { get; }
+
+        public AzureInfo Azure { get; }
+
+        public GitInfo Git { get; }
+
+        public class AzureInfo
+        {
+            public string InstanceId { get; set; }
+
+            public string SiteName { get; set; }
+        }
+
+        public class GitInfo
+        {
+            public string AuthorDate { get; set; }
+
+            public string Branch { get; set; }
+
+            public string CommitSha { get; set; }
+        }
+    }
+}

--- a/src/Ironclad/WebApi/RootController.cs
+++ b/src/Ironclad/WebApi/RootController.cs
@@ -3,33 +3,19 @@
 
 namespace Ironclad.WebApi
 {
-    using System;
-    using System.Diagnostics;
-    using System.Reflection;
     using Microsoft.AspNetCore.Mvc;
 
     [Route("api")]
     public class RootController : Controller
     {
-        private static readonly object Version =
-            new
-            {
-                Title = typeof(Program).Assembly.Attribute<AssemblyTitleAttribute>(attribute => attribute.Title),
-                Version = typeof(Program).Assembly.Attribute<AssemblyInformationalVersionAttribute>(attribute => attribute.InformationalVersion),
-                OS = System.Runtime.InteropServices.RuntimeInformation.OSDescription.TrimEnd(),
-                ProcessId = Process.GetCurrentProcess().Id,
-                Azure = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") != null
-                    ? new
-                    {
-                        InstanceId = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID"),
-                        SiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"),
-                        Hostname = Environment.GetEnvironmentVariable("WEBSITE_HOSTNAME"),
-                        SlotName = Environment.GetEnvironmentVariable("WEBSITE_SLOT_NAME"),
-                    }
-                    : null,
-            };
+        private readonly ApiInfo apiInfo;
+
+        public RootController(ApiInfo apiInfo)
+        {
+            this.apiInfo = apiInfo;
+        }
 
         [HttpGet]
-        public IActionResult Get() => this.Ok(Version);
+        public IActionResult Get() => this.Ok(this.apiInfo);
     }
 }


### PR DESCRIPTION
…from which the build has been run.

- takes ~300ms but runs only in Release or CI configuration
- works when you build/run Ironclad from Visual Studio
- works when you build from the command line `dotnet build`
- works when you specify custom build output path (like we do in Dockerfile) ie. `dotnet build -o /build`
- no dependencies on a CI
- no new dependencies for Ironclad (apart from Bullseye build script)

Result:
![image](https://user-images.githubusercontent.com/645656/53746956-89db8580-3ea2-11e9-8e20-196427dbe562.png)


Fixes https://github.com/LykkeOSS/ironclad/issues/136 and [IRON-52](https://lykkex.atlassian.net/browse/IRON-52)