### PR TITLE
IRON-91 Fixes #146 where IdP tests fail when Google is configured

### DIFF
--- a/src/Ironclad/WebApi/IdentityProvidersController.cs
+++ b/src/Ironclad/WebApi/IdentityProvidersController.cs
@@ -127,7 +127,7 @@ namespace Ironclad.WebApi
             }
             catch (ArgumentException ex)
             {
-                return this.BadRequest(new { Message = ex.Message });
+                return this.BadRequest(new { ex.Message });
             }
 
             this.logger.LogInformation($"Added '{identityProvider.Name}' identity provider");


### PR DESCRIPTION
Looks like now the Google auth is using OIDC that we need to use our External OIDC Provider store and not the default configuration process.